### PR TITLE
fix(routing): fix Windows normalize bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "rehype-react": "^6.1.0",
     "rss": "^1.2.2",
     "sanitize-html": "^2.2.0",
+    "slash": "^3.0.0",
     "unist-util-visit": "^2.0.3"
   },
   "devDependencies": {

--- a/utils/routing.ts
+++ b/utils/routing.ts
@@ -1,7 +1,9 @@
 import { normalize } from 'path'
+// Hot fix Windows normalize function returning backslash
+import slash from 'slash'
 
 // higher order function
-const withPrefixPath = (prefixPath: string) => (path: string) => normalize(`/${prefixPath}/${path}/`)
+const withPrefixPath = (prefixPath: string) => (path: string) => slash(normalize(`/${prefixPath}/${path}/`))
 
 const trimSlash = (text: string) => text.replace(/^\//, '').replace(/\/$/, '')
 
@@ -22,7 +24,7 @@ interface ResolveUrlProps {
 
 export const resolveUrl = ({ collectionPath = `/`, slug, url }: ResolveUrlProps) => {
   const resolvePath = withPrefixPath(collectionPath)
-  if (!slug || slug.length === 0) return normalize(resolvePath(`/`))
+  if (!slug || slug.length === 0) return slash(normalize(resolvePath(`/`)))
   if (!url || url.length === 0) return resolvePath(slug)
   if (trimSlash(url) === slug) return resolvePath(slug)
 


### PR DESCRIPTION
The use of normalize function from Node library in Windows return
unexpected backslash when normalizing slug. The use of normalize library
should be completely removed, as a hot fix I added the slash library to
revert Windows backslash.