### PR TITLE
Fixes styxlab/next-cms-ghost#6

### DIFF
--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -94,7 +94,11 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       if (dimensions) contactPage.featureImage = { url, dimensions }
     }
   }
-  if (!post && !page && !isContactPage) throw new Error(`Expected post or page for slug: ${slug}`)
+  if (!post && !page && !isContactPage) {
+    return {
+      notFound: true,
+    }
+  }
 
   let previewPosts: GhostPostsOrPages | never[] = []
   let prevPost: GhostPostOrPage | null = null
@@ -166,6 +170,6 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
   return {
     paths,
-    fallback: enable
+    fallback: enable && "blocking"
   }
 }

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -170,6 +170,6 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
   return {
     paths,
-    fallback: enable && "blocking"
+    fallback: enable && 'blocking'
   }
 }


### PR DESCRIPTION
Properly shows 404 page for non-existent pages now. Also switches to blocking fallback to send 404 status directly from the server, it can be disabled for pure UI based 404, but that's not recommended for SEO reasons.

![image](https://user-images.githubusercontent.com/1667481/103315686-52ad6f80-4a4c-11eb-99bf-51dfb8935416.png)
