### PR TITLE
Auto generate collections index page

### DIFF
--- a/lib/collections.ts
+++ b/lib/collections.ts
@@ -1,7 +1,7 @@
 import { collections as config } from '@routesConfig'
 
 export interface Collection<T> {
-  path: string
+  path: string,
   selector: (node: T) => boolean | null | undefined
 }
 

--- a/lib/collections.ts
+++ b/lib/collections.ts
@@ -1,7 +1,7 @@
 import { collections as config } from '@routesConfig'
 
 export interface Collection<T> {
-  path: string,
+  path: string
   selector: (node: T) => boolean | null | undefined
 }
 
@@ -13,8 +13,28 @@ export class Collections<T> {
   }
 
   getCollectionByNode(node: T) {
-    const { path } = this.collections.find(collection => collection.selector(node)) || { path: '/' }
+    const { path } = this.collections.find((collection) => collection.selector(node)) || { path: '/' }
     return path
+  }
+
+  isCollectionPath(slug: string) {
+    return !!this.collections.find((collection) => collection.path === slug)
+  }
+
+  filterPostsByCollectionPath = ({ collectionPath = `/`, posts }: { collectionPath?: string; posts: T[] }) => {
+    let filteredPosts = posts, foundCollection = false;
+    let collection: Collection<T> | undefined;
+    for (collection of this.collections) {
+      if (collection.path === collectionPath) {
+        foundCollection = true;
+        break;
+      }
+      filteredPosts = filteredPosts.filter((post) => !collection!.selector(post))
+    }
+    if (foundCollection) {
+      return filteredPosts.filter((post)=> collection!.selector(post))
+    }
+    return filteredPosts
   }
 }
 

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -29,11 +29,11 @@ import { BodyClass } from '@helpers/BodyClass'
  */
 
 interface CmsDataCore {
-  collection?: string
-  posts?: GhostPostsOrPages
-  post?: GhostPostOrPage
-  page?: GhostPostOrPage
-  contactPage?: ContactPage
+  collection: string
+  posts: GhostPostsOrPages
+  post: GhostPostOrPage
+  page: GhostPostOrPage
+  contactPage: ContactPage
   settings: GhostSettings
   seoImage: ISeoImage
   previewPosts?: GhostPostsOrPages
@@ -55,15 +55,14 @@ const PostOrPageIndex = ({ cmsData }: PostOrPageProps) => {
   const router = useRouter()
   if (router.isFallback) return <div>Loading...</div>
 
-  const { isPost, contactPage, isCollection, collection, posts, settings, seoImage, bodyClass } = cmsData
+  const { isPost, contactPage, isCollection } = cmsData
   if (isPost) {
-    // @ts-ignore
     return <Post {...{ cmsData }} />
   } else if (!!contactPage) {
     const { contactPage, previewPosts, settings, seoImage, bodyClass } = cmsData
-    // @ts-ignore
     return <Contact cmsData={{ page: contactPage, previewPosts, settings, seoImage, bodyClass }} />
   } else if (isCollection) {
+    const { collection, posts, settings, seoImage, bodyClass } = cmsData
     return (
       <>
         <SEO {...{ settings, title: collection || '', description: collection || '', seoImage }} />
@@ -73,14 +72,12 @@ const PostOrPageIndex = ({ cmsData }: PostOrPageProps) => {
       </>
     )
   } else {
-    // @ts-ignore
     return <Page cmsData={cmsData} />
   }
 }
 
 export default PostOrPageIndex
 
-// @ts-ignore
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   if (!(params && params.slug && Array.isArray(params.slug))) throw Error('getStaticProps: wrong parameters.')
   const [slug] = params.slug.reverse()
@@ -90,7 +87,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   let post: GhostPostOrPage | null = null
   let page: GhostPostOrPage | null = null
   let contactPage: ContactPage | null = null
-  let isCollection = collections.isCollectionPath(slug);
+  const isCollection = collections.isCollectionPath(slug)
 
   post = await getPostBySlug(slug)
   const isPost = !!post
@@ -165,23 +162,22 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       ...(processEnv.isr.enable && { revalidate: 1 }), // re-generate at most once every second
     }
   }
-  if (isCollection) {
-    const posts = collections.filterPostsByCollectionPath({ collectionPath: slug, posts: await getAllPosts()})
-    const settings = await getAllSettings()
-    return {
-      props: {
-        cmsData: {
-          collection: slug,
-          isPost,
-          isCollection,
-          posts,
-          settings,
-          seoImage: await seoImage({ siteUrl: settings.processEnv.siteUrl }),
-          bodyClass: BodyClass({isPost, page: undefined, tags: []}),
-        },
+
+  // must be a collection index page
+  const posts = collections.filterPostsByCollectionPath({ collectionPath: slug, posts: await getAllPosts()})
+  return {
+    props: {
+      cmsData: {
+        collection: slug,
+        isPost,
+        isCollection,
+        posts,
+        settings,
+        seoImage: await seoImage({ siteUrl: settings.processEnv.siteUrl }),
+        bodyClass: BodyClass({isPost, page: undefined, tags: []}),
       },
-      ...(processEnv.isr.enable && { revalidate: 1 }), // re-generate at most once every second
-    }
+    },
+    ...(processEnv.isr.enable && { revalidate: 1 }), // re-generate at most once every second
   }
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,6 +6,7 @@ import { PostView } from '@components/PostView'
 import { HeaderIndex } from '@components/HeaderIndex'
 import { StickyNavContainer } from '@effects/StickyNavContainer'
 import { SEO } from '@meta/seo'
+import { collections } from '@lib/collections'
 
 import { processEnv } from '@lib/processEnv'
 import { getAllPosts, getAllSettings, GhostPostOrPage, GhostPostsOrPages, GhostSettings } from '@lib/ghost'
@@ -62,7 +63,9 @@ export const getStaticProps: GetStaticProps = async () => {
 
   try {
     settings = await getAllSettings()
-    posts = await getAllPosts()
+    const allPosts = await getAllPosts()
+    posts = collections.filterPostsByCollectionPath({ posts: allPosts }) as GhostPostsOrPages
+    posts.meta = allPosts.meta
   } catch (error) {
     throw new Error('Index creation failed.')
   }


### PR DESCRIPTION
Automatically generate index page under the paths specified in `routesConfig.ts`. 

There are a couple of observations:

1. For some reason, when viewing a post under a collection path, Nextjs will request `favicon.png` and Ghost will report that it's an invalid slug. This doesn't affect the post at all but it'd be nice to know why Nextjs does that.
2. A post will always be reachable at the root as well as under the collection path. Not sure why and if it matters at all.

This PR assumes that the Ghost installation does NOT have its own collections setup.
