### PR TITLE
Patch the html ast to fix each header's Table of Content location

### DIFF
--- a/components/CorrectTocScript.tsx
+++ b/components/CorrectTocScript.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import Script from 'next/script'
+
+export const CorrectTocScript = (url: string) => {
+  return (
+    <Script
+      id={"CorrectTocScript" + new Date().getTime()}
+      src={"/empty.js"}
+      strategy="afterInteractive"
+      onLoad={() => {
+        var elems = document.querySelectorAll('h1,h2,h3,h4,h5,h6')
+        for (var i = 0; i < elems.length; i++) {
+          if (elems[i].getAttribute("scriptReady") == "true") continue;
+          elems[i].setAttribute("scriptReady", "true")
+
+          var tocDiv = document.createElement("div");
+          tocDiv.setAttribute("id", elems[i].getAttribute("id") || "undefined");
+          tocDiv.setAttribute("style", "position: relative; top: -80px;");
+          elems[i].parentNode?.insertBefore(tocDiv, elems[i])
+        }
+      }}
+    />
+  )
+}

--- a/components/CorrectTocScript.tsx
+++ b/components/CorrectTocScript.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Script from 'next/script'
 
-export const CorrectTocScript = (url: string) => {
+export const CorrectTocScript = () => {
   return (
     <Script
       id={"CorrectTocScript" + new Date().getTime()}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import { AppProps } from 'next/app'
 import { OverlayProvider } from '@components/contexts/overlayProvider'
 import { ThemeProvider } from '@components/contexts/themeProvider'
 import { processEnv } from '@lib/processEnv'
+import { CorrectTocScript } from '@components/CorrectTocScript'
 
 import '@styles/screen.css'
 import '@styles/screen-fixings.css'
@@ -10,10 +11,12 @@ import '@styles/prism.css'
 import '@styles/toc.css'
 
 function App({ Component, pageProps }: AppProps) {
+  const { url } = pageProps
   return (
     <ThemeProvider {...processEnv.darkMode} >
       <OverlayProvider >
         <Component {...pageProps} />
+        <CorrectTocScript { ...url || "" }/>
       </OverlayProvider>
     </ThemeProvider>
   )

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,12 +11,11 @@ import '@styles/prism.css'
 import '@styles/toc.css'
 
 function App({ Component, pageProps }: AppProps) {
-  const { url } = pageProps
   return (
     <ThemeProvider {...processEnv.darkMode} >
       <OverlayProvider >
         <Component {...pageProps} />
-        <CorrectTocScript { ...url || "" }/>
+        <CorrectTocScript/>
       </OverlayProvider>
     </ThemeProvider>
   )


### PR DESCRIPTION
Patches the html ast (on page load) to add a div with the right `id` before each header. 

```html
<h2 id="my-header">My header</h2>
```
becomes:
```html
<div id="my-header" style="position: relative; top: -80px;"></div>
<h2 id="my-header">My header</h2>
```


This essentially makes clicking the ToC work as intended by scrolling right before the corresponding header. Works on both desktop and mobile.

It works when clicking the table of content but not when accessing a URL at a specific ToC location like `https://my-url.com/#my-header` (which would scroll right below the header instead of right before). This is because when accessing through `https://my-url.com/#my-header` the browser scrolls before the html was patched. **Therefore**, it'd be even better to generate the html page like this from the start rather than patching it on page load.


ps: @styxlab, I just wanted to take the opportunity to thank you for open sourcing and documenting your Jamify projects on your blog. It's been a great help, really. 💯