### PR TITLE
Fix toggle cards css and open/close them when clicked.

### DIFF
--- a/components/ToggleScript.tsx
+++ b/components/ToggleScript.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import Script from 'next/script'
+
+export const ToggleScript = () => {
+  return (
+    <Script
+      id={"toggleScript" + new Date().getTime()}
+      src={"/empty.js"}
+      strategy="lazyOnload"
+      onLoad={() => {
+        var coll = document.getElementsByClassName("kg-toggle-card");
+        for (var i = 0; i < coll.length; i++) {
+          var elem = coll[i];
+          if (elem.getAttribute("scriptReady") == "true") continue;
+          elem.setAttribute("scriptReady", "true")
+
+          elem.addEventListener("click", function() {
+            if (elem?.getAttribute('data-kg-toggle-state') == 'close')
+              elem.setAttribute('data-kg-toggle-state', 'open')
+            else
+              elem?.setAttribute('data-kg-toggle-state', 'close')
+          });
+        }
+      }}
+    />
+  )
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import { AppProps } from 'next/app'
 import { OverlayProvider } from '@components/contexts/overlayProvider'
 import { ThemeProvider } from '@components/contexts/themeProvider'
 import { processEnv } from '@lib/processEnv'
+import { ToggleScript } from '@components/ToggleScript'
 
 import '@styles/screen.css'
 import '@styles/screen-fixings.css'
@@ -14,6 +15,7 @@ function App({ Component, pageProps }: AppProps) {
     <ThemeProvider {...processEnv.darkMode} >
       <OverlayProvider >
         <Component {...pageProps} />
+        <ToggleScript/>
       </OverlayProvider>
     </ThemeProvider>
   )

--- a/styles/screen.css
+++ b/styles/screen.css
@@ -2348,6 +2348,139 @@ html.casper .kg-bookmark-publisher {
     }
 }
 
+/*** Toggle and Callouts ***/
+html.casper .kg-callout-card .kg-callout-text,
+html.casper .kg-toggle-card .kg-toggle-content > ol,
+html.casper .kg-toggle-card .kg-toggle-content > ul,
+html.casper .kg-toggle-card .kg-toggle-content > p {
+    font-family: var(--font-serif);
+    font-weight: 400;
+    font-size: 1.9rem;
+    line-height: 1.6em;
+}
+
+html.casper .kg-toggle-card .kg-toggle-heading-text {
+    font-size: 2.0rem;
+}
+
+html.casper .kg-toggle-card .kg-toggle-content > ol,
+html.casper .kg-toggle-card .kg-toggle-content > ul,
+html.casper .kg-product-card .kg-product-card-description > ol,
+html.casper .kg-product-card .kg-product-card-description > ul {
+    padding-left: 1.9em;
+}
+
+@media (max-width: 650px) {
+    html.casper .kg-callout-card .kg-callout-text,
+    html.casper .kg-toggle-card .kg-toggle-content > ol,
+    html.casper .kg-toggle-card .kg-toggle-content > ul,
+    html.casper .kg-toggle-card .kg-toggle-content > p {
+        font-size: 1.7rem;
+    }
+}
+
+html.casper .kg-callout-card .kg-callout-text,
+html.casper .kg-toggle-card .kg-toggle-content > ol,
+html.casper .kg-toggle-card .kg-toggle-content > ul,
+html.casper .kg-toggle-card .kg-toggle-content > p {
+    font-family: var(--font-serif);
+    font-weight: 400;
+    font-size: 1.9rem;
+    line-height: 1.6em;
+}
+
+html.casper .kg-toggle-card {
+        background: 0 0;
+        box-shadow: inset 0 0 0 1px rgba(124, 139, 154, .25);
+        border-radius: 4px;
+        padding: 1.2em;
+    width: 100%;
+}
+
+html.casper .kg-toggle-card[data-kg-toggle-state=close] .kg-toggle-content {
+        height: 0;
+        overflow: hidden;
+        transition: opacity .5s ease, top .35s ease;
+        opacity: 0;
+        top: -.5em;
+        position: relative
+}
+
+html.casper .kg-toggle-content {
+        height: auto;
+        opacity: 1;
+        transition: opacity 1s ease, top .35s ease;
+        top: 0;
+        position: relative
+}
+
+html.casper .kg-toggle-card[data-kg-toggle-state=close] svg {
+        transform: unset
+}
+
+html.casper .kg-toggle-heading {
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start
+}
+
+html.casper .kg-toggle-card h4.kg-toggle-heading-text {
+        font-size: 1.15em;
+        font-weight: 700;
+        line-height: 1.3em;
+        margin-top: 0;
+        margin-bottom: 0
+}
+
+html.casper .kg-toggle-content p:first-of-type {
+        margin-top: .5em
+}
+
+html.casper .kg-toggle-card .kg-toggle-content ol,
+html.casper .kg-toggle-card .kg-toggle-content p,
+html.casper .kg-toggle-card .kg-toggle-content ul {
+        font-size: .95em;
+        line-height: 1.5em;
+        margin-top: .95em;
+        margin-bottom: 0
+}
+
+html.casper .kg-toggle-card-icon {
+        height: 24px;
+        width: 24px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin-left: -1em;
+        background: 0 0;
+        border: 0
+}
+
+html.casper .kg-toggle-heading svg {
+        width: 14px;
+        color: rgba(124, 139, 154, .5);
+        transition: all .3s;
+        transform: rotate(-180deg)
+}
+
+html.casper .kg-toggle-heading path {
+        fill: none;
+        stroke: currentcolor;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke-width: 1.5;
+        fill-rule: evenodd
+}
+
+html.casper .kg-toggle-card+.kg-toggle-card {
+        margin-top: 1em
+}
+
+html.casper .kg-toggle-card li+li {
+        margin-top: .5em
+}
+
 /* 8. Author Template
 /* ---------------------------------------------------------- */
 html.casper .author-header {


### PR DESCRIPTION
I noticed the toggle cards from the Ghost editor were not displaying correctly and would not open or close. This PR fixes that.
