### PR TITLE
Improved disqus settings to use the provided site URL.

### DIFF
--- a/components/DisqusComments.tsx
+++ b/components/DisqusComments.tsx
@@ -1,13 +1,16 @@
 import { DiscussionEmbed } from 'disqus-react'
 import { GhostPostOrPage } from '@lib/ghost'
+import { resolvePostFullPath } from '@utils/routing'
 
 interface DisqusCommentsProps {
   post: GhostPostOrPage
   shortname: string
+  siteUrl: string
 }
 
-export const DisqusComments = ({ post, shortname }: DisqusCommentsProps) => {
-  const { url, id: identifier, title } = post
+export const DisqusComments = ({ post, shortname, siteUrl }: DisqusCommentsProps) => {
+  const url = resolvePostFullPath(siteUrl, post.slug)
+  const { id: identifier, title } = post
   const config = { url, identifier, title }
 
   return (

--- a/components/Post.tsx
+++ b/components/Post.tsx
@@ -156,7 +156,7 @@ export const Post = ({ cmsData }: PostProps) => {
 
                 {commenting.system === 'commento' && <CommentoComments {...{ id: post.id, url: commenting.commentoUrl }} />}
 
-                {commenting.system === 'disqus' && <DisqusComments {...{ post, shortname: commenting.disqusShortname }} />}
+                {commenting.system === 'disqus' && <DisqusComments {...{ post, shortname: commenting.disqusShortname, siteUrl: processEnv.siteUrl }} />}
               </article>
             </div>
           </Layout>

--- a/utils/routing.ts
+++ b/utils/routing.ts
@@ -38,3 +38,7 @@ export const resolveUrl = ({ cmsUrl, collectionPath = `/`, slug, url }: ResolveU
   const dirUrl = url.replace(cmsUrl, '/').replace('//', '/')
   return resolvePath(dirUrl)
 }
+
+export const resolvePostFullPath = (siteUrl: string, slug: string) => {
+  return `${trimSlash(siteUrl)}/${slug}`
+}


### PR DESCRIPTION
@styxlab  here's a PR to address a small bug with the Disqus integration.

Actually, once the comments form is displayed, a click on the share buttons (Twitter or Facebook) is using the post URL coming from Ghost which is using the CMS URL instead of the site URL.

I have implemented a very minimalist solution that is 100% working, do let me know what you think about it.

Cheers!