### PR TITLE
Fix target height not being computed in site nav logo

### DIFF
--- a/components/SiteNav.tsx
+++ b/components/SiteNav.tsx
@@ -68,7 +68,7 @@ export const SiteNav = ({ settings, className, postTitle }: SiteNavProps) => {
               <a className="site-nav-logo">
                 <div
                   style={{
-                    height: '${targetHeight}px',
+                    height: `${targetHeight}px`,
                     width: `${calcSiteLogoWidth(siteLogo, targetHeight)}px`,
                   }}
                 >


### PR DESCRIPTION
`targetHeight` value is not being computed because of missing template literals, therefore wrong CSS is being produced as seen in the following screenshot. This PR fixes it.

![image](https://user-images.githubusercontent.com/5151628/154983960-e397997e-0f6b-4eb0-943b-0e98fdf1048a.png)
