### PR TITLE
Fix issue if <a> tag has an id attribute but no href

### DIFF
--- a/lib/ghost-normalize.ts
+++ b/lib/ghost-normalize.ts
@@ -62,7 +62,7 @@ const withRewriteGhostLinks =
   (cmsUrl: UrlWithStringQuery, basePath = '/') =>
   (htmlAst: Node) => {
     visit(htmlAst, { tagName: `a` }, (node: LinkElement) => {
-      if (!node.properties) return
+      if (!node.properties || !node.properties.href) return
       const href = urlParse(node.properties.href)
       if (href.protocol === cmsUrl.protocol && href.host === cmsUrl.host) {
         node.properties.href = basePath + href.pathname?.substring(1)


### PR DESCRIPTION
I have a post in Ghost that has an `id` attribute directly on the anchor tag, but no href. Previously this would generate a build error. With this fix the `<a>` tag will be rendered with the `id` attribute, but `withRewriteGhostLinks()` will no longer try to parse an undefined `href`.